### PR TITLE
Explicit dependency on aiofiles

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,4 +36,5 @@ setuptools.setup(
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Operating System :: OS Independent",
     ],
+    install_requires=["aiofiles>=0.6.0"],
 )


### PR DESCRIPTION
For those who wants to use `asynctempfile` without knowing about `aiofiles`, install pass succesfully and breaks only in import time.
Expliciting the requirement will cause `aiofiles` to automatically install with `asynctempfile`, if not already present.